### PR TITLE
Early master delegation on quorum loss

### DIFF
--- a/src/elector.cpp
+++ b/src/elector.cpp
@@ -671,7 +671,7 @@ namespace koi {
 		auto* su = m->set_body<msg::stateupdate>();
 		m->_seqnr = _emitter._current_tick;
 
-		su->_uptime = _emitter.uptime(_starttime);
+		su->_uptime = _emitter.uptime(_leadertime);
 		su->_maintenance = _emitter._nexus.cfg()._cluster_maintenance;
 
 		if (_master != _runners.end()) {


### PR DESCRIPTION
When a the quorum is temporarily lost there is the risk that a master gets delegated before the elector startup tolerance time has elapsed.

I'm not sure this is the best/correct solution, but it seems to fix the issue :)

Introduced by 260b1fb
