### PR TITLE
Disabled service is considered as service failure.

### DIFF
--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -279,8 +279,10 @@ namespace koi {
 		_emitter.update();
 
 		_check_timeouts(now);
-		_update_elector_state(now);
-		_check_recovery(now);
+		if (!_services.is_disabled()) {
+			_update_elector_state(now);
+			_check_recovery(now);
+		}
 		_check_service_status();
 	}
 

--- a/src/servicemgr.hpp
+++ b/src/servicemgr.hpp
@@ -170,6 +170,7 @@ namespace koi {
 		bool complete_transition(ptime now, service& s);
 		bool check_exitcode(service& s);
 		void toggle_logproxy();
+		bool is_disabled();
 
 		bool resolves(ServiceState state, ServiceAction action) const;
 		bool matches(ServiceState state, ServiceAction action) const;


### PR DESCRIPTION
Issue: koi does not failover, when a service is disabled at master node.

Fix: Service manager will return failure when service is disabled.
Hence runner will stop all the services and move to failed state.
Also runner will not perform failure recovery and elector state update,
when the service is disabled.
