### PR TITLE
Elector's _leadertime is reset when quorum is lost/gained.

### DIFF
--- a/src/elector.hpp
+++ b/src/elector.hpp
@@ -152,6 +152,7 @@ namespace koi {
 		ptime             _leadertime;
 		ptime             _last_state_save;
 		uint32_t          _state_sum;
+		bool              _lost_quorum;
 	};
 
 }


### PR DESCRIPTION
_leadertime is reset when elector loses/gains quorum. Hence elector
will not promote/demote any node immediately after it gains quorum.
Elector that just gained quorum will get some more time to know
that if any of the newly connected node is master. Hence, Unnecessary
promotion/demotion will be avoided.
