### PR TITLE
Send maintenance mode configuration from elector to all nodes

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -50,7 +50,7 @@ const char* koi::nodeflags_to_string(int flags) {
 	return fval[flags];
 }
 
-cluster::cluster(nexus& route, const settings& cfg)
+cluster::cluster(nexus& route, settings& cfg)
 	: _state(),
 	  _network(route, cfg._cluster_id),
 	  _on_up(),
@@ -265,6 +265,15 @@ void cluster::update_state(const message& m) {
 			                         n._name,
 			                         n._flags,
 			                         ep);
+		}
+		// TODO FIXME BUG
+		// Setting the node that's in maintenance, in maintenance,
+		// will spread that state only if the elector happens to
+		// be running on that node...
+		// If the elector node is THIS node, we are already up to date
+		if (_cfg._cluster_maintenance != hb->_cluster_maintenance) {
+			_cfg._cluster_maintenance = hb->_cluster_maintenance;
+			LOG_INFO("Maintenance mode: %s", (hb->_cluster_maintenance ? "ON" : "OFF"));
 		}
 		if (changed) {
 			_on_state_change(this);

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -39,7 +39,7 @@ namespace koi {
 			Leader = 2
 		};
 
-		cluster(nexus& route, const settings& cfg);
+		cluster(nexus& route, settings& cfg);
 		~cluster();
 
 		bool settings_changed(const settings& newcfg, const settings& oldcfg);
@@ -72,7 +72,7 @@ namespace koi {
 		action         _on_up;
 		action         _on_down;
 		action         _on_state_change;
-		const settings&_cfg;
+		settings&      _cfg;
 
 		uuid           _leader;
 		int64_t        _t;

--- a/src/elector.cpp
+++ b/src/elector.cpp
@@ -698,7 +698,6 @@ namespace koi {
 		m->_seqnr = _emitter._current_tick;
 
 		su->_uptime = _emitter.uptime(_leadertime);
-		su->_maintenance = _emitter._nexus.cfg()._cluster_maintenance;
 
 		if (_master != _runners.end()) {
 			su->_master_uuid = _master->second._uuid;

--- a/src/koi.hpp
+++ b/src/koi.hpp
@@ -16,7 +16,7 @@
 */
 #pragma once
 
-#define KOI_VERSION 4
+#define KOI_VERSION 5
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -156,7 +156,6 @@ namespace {
 
 	void write_archive(archive& a, const stateupdate* su) {
 		a << su->_uptime
-		  << su->_maintenance
 		  << su->_master_uuid;
 		if (!su->_master_uuid.is_nil()) {
 			a << su->_master_last_seen
@@ -167,7 +166,6 @@ namespace {
 
 	void read_archive(reader& r, stateupdate* su) {
 		r >> su->_uptime
-		  >> su->_maintenance
 		  >> su->_master_uuid;
 		if (!su->_master_uuid.is_nil()) {
 			r >> su->_master_last_seen
@@ -191,6 +189,7 @@ namespace {
 			a << true
 			  << hb->_elector
 			  << hb->_master
+			  << hb->_cluster_maintenance
 			  << (int)hb->_nodes.size();
 			FOREACH(heartbeat::node const& n, hb->_nodes) {
 				a << n._id << n._name << n._last_seen << n._flags << n._addrs;
@@ -208,6 +207,7 @@ namespace {
 			int nnodes;
 			r >> hb->_elector
 			  >> hb->_master
+			  >> hb->_cluster_maintenance
 			  >> nnodes;
 			// TODO: range-check nnodes
 			for (int i = 0; i < nnodes; ++i) {

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -113,7 +113,6 @@ namespace koi {
 			virtual ~stateupdate() {}
 
 			uint64_t _uptime;
-			bool _maintenance;
 
 			// master node information
 			uuid _master_uuid;
@@ -212,6 +211,7 @@ namespace koi {
 			nodes _nodes;
 			uuid _elector;
 			uuid _master;
+			bool _cluster_maintenance;
 		};
 
 #define MessageBodyMethods(id, cls)	  \

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -57,6 +57,7 @@ void network::send(const uuid& ID, const string& name, const clusterstate& s, in
 	copy(s._nodes.begin(), s._nodes.end(), back_inserter(hb->_nodes));
 	hb->_elector = s._elector;
 	hb->_master = s._master;
+	hb->_cluster_maintenance = _nexus.cfg()._cluster_maintenance;
 	_nexus.send(m);
 }
 

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -314,16 +314,6 @@ namespace koi {
 		_elector._uptime = su->_uptime;
 
 		if (_elector._uuid != _emitter._nexus.cfg()._uuid) {
-			// TODO FIXME BUG
-			// Setting the node that's in maintenance, in maintenance,
-			// will spread that state only if the elector happens to
-			// be running on that node...
-			// If the elector node is THIS node, we are already up to date
-			if (_emitter._nexus.cfg()._cluster_maintenance != su->_maintenance) {
-				_emitter._nexus.cfg()._cluster_maintenance = su->_maintenance;
-				LOG_INFO("Maintenance mode: %s", (su->_maintenance ? "ON" : "OFF"));
-			}
-
 			// Update the masterstate, so that in case of failover,
 			// we're up to date. Don't do this if we're the elector
 			// since the elector will be updating the masterstate.


### PR DESCRIPTION
Maintenance mode configuration was sent as part of state update
message. State update message is sent from elector node to runner
nodes only. Hence, non-runner nodes is never updated with the new
maintenance mode configuration. When a non-runner happens to
become as an elector, it starts updating the old maintenance mode
configuration to runners. So, the cluster gets out of maintenance
mode. Fix is done to send maintenance mode configuration from
elector to all cluster nodes as part of heartbeat messages.