### PR TITLE
KOI should first try to terminate a service with SIGTERM

### DIFF
--- a/src/servicemgr.hpp
+++ b/src/servicemgr.hpp
@@ -118,7 +118,7 @@ namespace koi {
 		};
 
 		typedef std::map<string, service> services;
-
+		static const size_t TERMINATE_TIMEOUT;
 
 		void init(const char* servicesdir, const char* workingdir);
 		~service_manager();


### PR DESCRIPTION
before a SIGKILL. This will help the child process to
handle the SIGTERM and clean up stale files and terminate
their child processes.