### PR TITLE
BUG: Don't stop newly spawned action right away

### DIFF
--- a/src/servicemgr.hpp
+++ b/src/servicemgr.hpp
@@ -168,7 +168,7 @@ namespace koi {
 		void wait_for_demote(bool maintenance_mode);
 		void wait_for_stop(bool maintenance_mode);
 		bool complete_transition(ptime now, service& s);
-		bool check_exitcode(service& s);
+		bool check_exitcode(service& s, bool& spawned_action);
 		void toggle_logproxy();
 		bool is_disabled();
 


### PR DESCRIPTION
While checking exit codes a new action can be spawned if there is
a mismatch between expected state and real state. This newly spawned
action was incorrectly stopped right away which caused the action
not to block following status checks. So koi was spawning many
instances of the same action waiting in defunct state. Koi is fixed
such that a newly spawned action will be stopped only if the action
script has completed.